### PR TITLE
include pattern option in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ const Metalsmith = require('metalsmith'),
 
 Metalsmith(__dirname)
     .use(handlebars({
+        pattern: '**/*.hbs', // defaults to '**'
         partials: 'partials', // defaults to 'partials' in the root
         targetExtension: 'html' // defaults to html
     }))


### PR DESCRIPTION
The default value of `**` can be quite confusing for most people, as it will transform _all_ files, including styles, and change their extensions to `.html`. Including `pattern` parameter in the documentation will make things more clear, I guess. What do you think?